### PR TITLE
Padroniza altura dos cards de preços e adiciona toggle Duo/Individual

### DIFF
--- a/script.js
+++ b/script.js
@@ -126,6 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // Pricing plans toggle
     const pricingButtons = document.querySelectorAll('#pricing .sub-tab-btn');
     const pricingGrid = document.querySelector('#pricing .pricing-grid');
+    let baseCardHeight;
 
     const pricingPlans = {
         presencial: [
@@ -274,11 +275,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 <div class="pricing-header">
                     <h3 class="plan-name">${plan.name}</h3>
                     <p class="plan-description">${plan.description}</p>
+                    ${plan.duo ? `
+                    <div class="pricing-toggle">
+                        <button class="btn-duo active" data-type="individual">Individual</button>
+                        <button class="btn-duo" data-type="duo">Duo</button>
+                    </div>` : ''}
                 </div>
                 <div class="pricing-price">
                     <span class="price"${isNumeric ? ` data-individual="${plan.price}" data-duo="${(plan.price * 0.85).toFixed(2)}"` : ''}>${priceDisplay}</span>
                     <span class="period">${plan.period}</span>
-                    ${plan.duo ? '<button class="btn-duo">Duo</button>' : ''}
                 </div>
                 <ul class="pricing-features">
                     ${plan.features.map(f => `<li><i class="fas fa-check"></i> ${f}</li>`).join('')}
@@ -289,21 +294,25 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function initDuoToggle() {
-        document.querySelectorAll('#pricing .btn-duo').forEach(btn => {
-            btn.addEventListener('click', () => {
-                const card = btn.closest('.pricing-card');
-                const priceEl = card.querySelector('.price');
-                const periodEl = card.querySelector('.period');
-                const isActive = btn.classList.toggle('active');
-                if (isActive) {
-                    priceEl.textContent = formatPrice(priceEl.dataset.duo);
-                    periodEl.textContent = '/aula por pessoa';
-                    btn.textContent = 'Individual';
-                } else {
-                    priceEl.textContent = formatPrice(priceEl.dataset.individual);
-                    periodEl.textContent = '/aula';
-                    btn.textContent = 'Duo';
-                }
+        document.querySelectorAll('#pricing .pricing-card').forEach(card => {
+            const priceEl = card.querySelector('.price');
+            const periodEl = card.querySelector('.period');
+            const btnInd = card.querySelector('[data-type="individual"]');
+            const btnDuo = card.querySelector('[data-type="duo"]');
+            if (!btnInd || !btnDuo) return;
+
+            btnInd.addEventListener('click', () => {
+                priceEl.textContent = formatPrice(priceEl.dataset.individual);
+                periodEl.textContent = '/aula';
+                btnInd.classList.add('active');
+                btnDuo.classList.remove('active');
+            });
+
+            btnDuo.addEventListener('click', () => {
+                priceEl.textContent = formatPrice(priceEl.dataset.duo);
+                periodEl.textContent = '/aula por pessoa';
+                btnDuo.classList.add('active');
+                btnInd.classList.remove('active');
             });
         });
     }
@@ -361,8 +370,12 @@ document.addEventListener('DOMContentLoaded', function () {
     function renderPricing(category) {
         if (!pricingPlans[category]) return;
         pricingGrid.innerHTML = pricingPlans[category].map(createPlanCard).join('');
+        if (!baseCardHeight) {
+            baseCardHeight = Math.max(...Array.from(pricingGrid.querySelectorAll('.pricing-card')).map(c => c.offsetHeight));
+            document.documentElement.style.setProperty('--pricing-card-height', baseCardHeight + 'px');
+        }
+        initDuoToggle();
         if (category === 'presencial') {
-            initDuoToggle();
             initPresencialCalculator();
         }
     }

--- a/style.css
+++ b/style.css
@@ -648,6 +648,9 @@ max-height: 100px;
     position: relative;
     transition: all 0.3s ease;
     border: 2px solid transparent;
+    min-height: var(--pricing-card-height, auto);
+    display: flex;
+    flex-direction: column;
 }
 
 .pricing-card:hover {
@@ -696,6 +699,13 @@ max-height: 100px;
     margin-bottom: 2rem;
 }
 
+.pricing-toggle {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
 .pricing-price .price {
     font-family: 'Montserrat', sans-serif;
     font-weight: 800;
@@ -709,7 +719,6 @@ max-height: 100px;
 }
 
 .btn-duo {
-    margin-top: 0.5rem;
     background: transparent;
     color: var(--primary);
     border: 1px solid var(--primary);
@@ -719,6 +728,7 @@ max-height: 100px;
     cursor: pointer;
     transition: all 0.3s ease;
 }
+
 
 .btn-duo.active,
 .btn-duo:hover {
@@ -732,6 +742,10 @@ max-height: 100px;
     border-radius: 20px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
     text-align: left;
+}
+
+.pricing-card a.btn {
+    margin-top: auto;
 }
 
 .calculator h4 {


### PR DESCRIPTION
## Resumo
- Garante que todos os cards de planos tenham a mesma altura com base nos planos presenciais
- Adiciona botões Duo e Individual lado a lado nos cards presenciais

## Testes
- `node --check script.js`
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9362cd5c8323878670b47b53d5d0