### PR TITLE
Add mobile pricing carousel arrows and duo plan toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,11 @@
                 <button class="sub-tab-btn" data-category="online">Online</button>
                 <button class="sub-tab-btn" data-category="liberacao">Liberação</button>
             </div>
-            <div class="pricing-grid"></div>
+            <div class="pricing-carousel">
+                <button class="pricing-arrow pricing-prev"><i class="fas fa-chevron-left"></i></button>
+                <div class="pricing-grid"></div>
+                <button class="pricing-arrow pricing-next"><i class="fas fa-chevron-right"></i></button>
+            </div>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -135,6 +135,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const pricingButtons = document.querySelectorAll('#pricing .sub-tab-btn');
     const pricingGrid = document.querySelector('#pricing .pricing-grid');
     let baseCardHeight;
+    let currentPricingIndex = 0;
 
     const pricingPlans = {
         presencial: [
@@ -321,38 +322,16 @@ document.addEventListener('DOMContentLoaded', function () {
         `;
     }
 
-    function initDuoToggle() {
-        document.querySelectorAll('#pricing .pricing-card').forEach(card => {
-            const priceEl = card.querySelector('.price');
-            const periodEl = card.querySelector('.period');
-            const btnInd = card.querySelector('[data-type="individual"]');
-            const btnDuo = card.querySelector('[data-type="duo"]');
-            if (!btnInd || !btnDuo) return;
-
-            btnInd.addEventListener('click', () => {
-                priceEl.textContent = formatPrice(priceEl.dataset.individual);
-                periodEl.textContent = '/aula';
-                btnInd.classList.add('active');
-                btnDuo.classList.remove('active');
-            });
-
-            btnDuo.addEventListener('click', () => {
-                priceEl.textContent = formatPrice(priceEl.dataset.duo);
-                periodEl.textContent = '/aula por pessoa';
-                btnDuo.classList.add('active');
-                btnInd.classList.remove('active');
-            });
-        });
-    }
-
     function initPresencialCalculator() {
         document.querySelectorAll('#pricing .pricing-card').forEach(card => {
             const timesInput = card.querySelector('.calc-times');
             const planSelect = card.querySelector('.calc-plan');
             const totalEl = card.querySelector('.calc-total');
+            const priceEl = card.querySelector('.price');
+            const periodEl = card.querySelector('.period');
             const price = parseFloat(card.dataset.price);
             const weeks = parseInt(card.dataset.weeks, 10);
-            if (!timesInput || !planSelect || !totalEl || !price || !weeks) return;
+            if (!timesInput || !planSelect || !totalEl || !price || !weeks || !priceEl || !periodEl) return;
 
             function updateCalc() {
                 const times = parseInt(timesInput.value, 10);
@@ -367,9 +346,45 @@ document.addEventListener('DOMContentLoaded', function () {
                 totalEl.textContent = formatPrice(total);
             }
 
+            function updatePrice() {
+                if (planSelect.value === 'duo') {
+                    priceEl.textContent = formatPrice(priceEl.dataset.duo);
+                    periodEl.textContent = '/aula /aluno';
+                } else {
+                    priceEl.textContent = formatPrice(priceEl.dataset.individual);
+                    periodEl.textContent = '/aula';
+                }
+            }
+
             timesInput.addEventListener('input', updateCalc);
-            planSelect.addEventListener('change', updateCalc);
+            planSelect.addEventListener('change', () => {
+                updatePrice();
+                updateCalc();
+            });
+
+            updatePrice();
         });
+    }
+
+    function initPricingCarousel() {
+        const prevBtn = document.querySelector('#pricing .pricing-prev');
+        const nextBtn = document.querySelector('#pricing .pricing-next');
+        const cards = pricingGrid.querySelectorAll('.pricing-card');
+        if (!prevBtn || !nextBtn || cards.length === 0 || window.innerWidth > 768) return;
+        currentPricingIndex = 0;
+        pricingGrid.style.transform = 'translateX(0)';
+        prevBtn.onclick = () => {
+            if (currentPricingIndex > 0) {
+                currentPricingIndex--;
+                pricingGrid.style.transform = `translateX(-${currentPricingIndex * 100}%)`;
+            }
+        };
+        nextBtn.onclick = () => {
+            if (currentPricingIndex < cards.length - 1) {
+                currentPricingIndex++;
+                pricingGrid.style.transform = `translateX(-${currentPricingIndex * 100}%)`;
+            }
+        };
     }
 
     function renderPricing(category) {
@@ -379,10 +394,10 @@ document.addEventListener('DOMContentLoaded', function () {
             baseCardHeight = Math.max(...Array.from(pricingGrid.querySelectorAll('.pricing-card')).map(c => c.offsetHeight));
             document.documentElement.style.setProperty('--pricing-card-height', baseCardHeight + 'px');
         }
-        initDuoToggle();
         if (category === 'presencial') {
             initPresencialCalculator();
         }
+        initPricingCarousel();
     }
 
     pricingButtons.forEach(btn => {

--- a/style.css
+++ b/style.css
@@ -664,6 +664,35 @@ h6 {
     margin-bottom: 3rem;
 }
 
+.pricing-carousel {
+    position: relative;
+}
+
+.pricing-arrow {
+    display: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 1;
+    justify-content: center;
+    align-items: center;
+}
+
+.pricing-prev {
+    left: -10px;
+}
+
+.pricing-next {
+    right: -10px;
+}
+
 .pricing-card {
     background: var(--bg-card);
     padding: 2.5rem;
@@ -1258,19 +1287,22 @@ h6 {
 
     .pricing-grid {
         display: flex;
-        overflow-x: auto;
-        scroll-snap-type: x mandatory;
-        -webkit-overflow-scrolling: touch;
-        gap: 1rem;
+        overflow: hidden;
+        gap: 0;
+        transition: transform 0.3s ease;
+        touch-action: pan-y;
     }
 
     .pricing-card {
         flex: 0 0 100%;
-        scroll-snap-align: start;
     }
 
     .pricing-card.featured {
         transform: none;
+    }
+
+    .pricing-arrow {
+        display: flex;
     }
 
     .footer-bottom {


### PR DESCRIPTION
## Summary
- Add navigation arrows to pricing card carousel on mobile
- Update Presencial plan selector to adjust price and unit when Duo is chosen
- Implement JS carousel logic to move cards only via arrows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ebe32b63083239f4f48b30ff87c53