### PR TITLE
Send contact form submissions via FormSubmit

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,6 +425,8 @@
                     </div>
                 </div>
                 <form class="contact-form" id="contactForm">
+                    <input type="hidden" name="_subject" value="Novo contato do site">
+                    <input type="hidden" name="_captcha" value="false">
                     <div class="form-group">
                         <input type="text" id="name" name="name" placeholder="Seu nome completo" required>
                     </div>

--- a/script.js
+++ b/script.js
@@ -472,24 +472,37 @@ document.addEventListener('DOMContentLoaded', function () {
                 return;
             }
 
-            // Prepare email
-            const mailSubject = 'Contato via site';
-            const mailBody = `Nome: ${name}\nEmail: ${email}\nTelefone: ${phone}\nServiço: ${service}\nMensagem: ${message || ''}`;
-            const mailtoLink = `mailto:iansr.estudos@gmail.com?subject=${encodeURIComponent(mailSubject)}&body=${encodeURIComponent(mailBody)}`;
-
             // Feedback to user
             const submitBtn = contactForm.querySelector('button[type="submit"]');
             const originalText = submitBtn.innerHTML;
             submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Enviando...';
             submitBtn.disabled = true;
 
-            setTimeout(() => {
-                window.location.href = mailtoLink;
-                showNotification('Mensagem pronta no seu e-mail.', 'success');
-                contactForm.reset();
-                submitBtn.innerHTML = originalText;
-                submitBtn.disabled = false;
-            }, 500);
+            // Send email using FormSubmit
+            fetch('https://formsubmit.co/ajax/iansr.estudos@gmail.com', {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'Accept': 'application/json'
+                }
+            })
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Erro ao enviar');
+                    }
+                    return response.json();
+                })
+                .then(() => {
+                    showNotification('Mensagem enviada com sucesso!', 'success');
+                    contactForm.reset();
+                })
+                .catch(() => {
+                    showNotification('Ocorreu um erro ao enviar sua mensagem. Tente novamente.', 'error');
+                })
+                .finally(() => {
+                    submitBtn.innerHTML = originalText;
+                    submitBtn.disabled = false;
+                });
         });
     }
 


### PR DESCRIPTION
## Summary
- send contact form via FormSubmit service without opening user's email client
- add hidden inputs for email subject and captcha disabling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924d04aee08323b6d65095ee805d11