### PR TITLE
Adicionar página de pagamento para o plano Online Mensal

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pagamento - Plano Online Mensal</title>
+    <meta name="description" content="Finalize o pagamento do plano online mensal de consultoria com personal trainer.">
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/icons/favicon-16x16.png">
+    <link rel="manifest" href="/assets/images/icons/site.webmanifest">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;800&family=Open+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="payment-body">
+    <header class="payment-header">
+        <a class="payment-logo" href="index.html">
+            <img src="assets/images/logo ian personal.png" alt="Ian Siqueira Personal Trainer">
+        </a>
+    </header>
+
+    <main class="payment-main">
+        <section class="payment-card">
+            <div class="payment-tag">Plano selecionado</div>
+            <h1>Online Mensal</h1>
+            <p class="payment-subtitle">Consultoria personalizada para treinar com autonomia e acompanhamento profissional.</p>
+            <div class="payment-price">
+                <span class="payment-value">R$ 80</span>
+                <span class="payment-period">/mês</span>
+            </div>
+
+            <ul class="payment-features">
+                <li><i class="fas fa-check"></i> Avaliação inicial online ou presencial (conforme disponibilidade).</li>
+                <li><i class="fas fa-check"></i> Aplicativo exclusivo com treinos personalizados.</li>
+                <li><i class="fas fa-check"></i> Correção de movimentos por vídeo.</li>
+                <li><i class="fas fa-check"></i> Suporte direto via WhatsApp.</li>
+            </ul>
+
+            <a class="btn btn-primary payment-cta" href="https://mpago.li/1JzpvY8" target="_blank" rel="noopener">
+                <i class="fas fa-lock"></i>
+                Contratar
+            </a>
+            <p class="payment-note">Pagamento seguro. Você será redirecionado para o checkout.</p>
+            <a class="payment-help" href="https://wa.me/55019997088455" target="_blank" rel="noopener">
+                <i class="fab fa-whatsapp"></i> Precisa de ajuda? Fale comigo
+            </a>
+        </section>
+    </main>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -171,7 +171,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 button: {
                     text: 'Assinar',
                     class: 'btn-outline',
-                    href: 'https://mpago.li/1JzpvY8'
+                    href: 'payment.html'
                 },
                 featured: false
             }

--- a/style.css
+++ b/style.css
@@ -1465,3 +1465,136 @@ h6 {
 .footer li {
     color: #ccc;
 }
+
+/* Payment Page */
+.payment-body {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-dark);
+}
+
+.payment-header {
+    padding: 24px 20px 0;
+    display: flex;
+    justify-content: center;
+}
+
+.payment-logo img {
+    max-height: 72px;
+}
+
+.payment-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px 20px 48px;
+}
+
+.payment-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: 24px;
+    padding: 32px 24px;
+    max-width: 520px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.payment-tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 107, 53, 0.15);
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 6px 16px;
+    border-radius: 999px;
+    margin-bottom: 16px;
+}
+
+.payment-card h1 {
+    font-size: 2rem;
+    margin-bottom: 12px;
+}
+
+.payment-subtitle {
+    color: #ccc;
+    margin-bottom: 20px;
+}
+
+.payment-price {
+    display: flex;
+    align-items: baseline;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 24px;
+}
+
+.payment-value {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: var(--text-light);
+}
+
+.payment-period {
+    color: #ccc;
+    font-size: 1rem;
+}
+
+.payment-features {
+    list-style: none;
+    text-align: left;
+    display: grid;
+    gap: 12px;
+    margin-bottom: 28px;
+}
+
+.payment-features i {
+    color: var(--primary);
+    margin-right: 8px;
+}
+
+.payment-cta {
+    width: 100%;
+    justify-content: center;
+}
+
+.payment-note {
+    margin-top: 12px;
+    color: #ccc;
+    font-size: 0.95rem;
+}
+
+.payment-help {
+    margin-top: 18px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-light);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.payment-help:hover {
+    color: var(--primary);
+}
+
+@media (max-width: 480px) {
+    .payment-card {
+        padding: 28px 20px;
+    }
+
+    .payment-card h1 {
+        font-size: 1.8rem;
+    }
+
+    .payment-value {
+        font-size: 2.1rem;
+    }
+}


### PR DESCRIPTION
### Motivation
- Criar uma página exclusiva e otimizada para mobile para o plano "Online Mensal" de R$ 80, exibindo detalhes do plano e um CTA que leva ao checkout, mantendo o padrão de cores da landing page.

### Description
- Adiciona o arquivo `payment.html` com conteúdo do plano, lista de benefícios e botão "Contratar" que redireciona ao checkout externo.;
- Atualiza `script.js` para alterar o CTA do plano online de `https://mpago.li/1JzpvY8` para apontar para a nova página `payment.html`;
- Adiciona estilos em `style.css` sob a seção "Payment Page" reutilizando variáveis de cor e tipografia existentes e incluindo regras responsivas para telas pequenas;
- Mantém o checkout final apontando para `https://mpago.li/1JzpvY8` a partir da nova `payment.html` para preservar o fluxo de pagamento já configurado.

### Testing
- Serviu os arquivos localmente com `python -m http.server 8000` com sucesso; 
- Executou um script Playwright que abriu `http://127.0.0.1:8000/payment.html` em viewport mobile e gerou `artifacts/payment-page.png`, mostrando o layout renderizado corretamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973dfe178ac8323a05339a187cef841)