### PR TITLE
Adicionar página de confirmação de pagamento com botão gatilho para N8N

### DIFF
--- a/payment-confirmation.html
+++ b/payment-confirmation.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Confirmação de Pagamento</title>
+    <meta name="description" content="Confirme seu pagamento e finalize o acesso ao seu plano.">
+
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/icons/favicon-16x16.png">
+    <link rel="manifest" href="/assets/images/icons/site.webmanifest">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700;800&family=Open+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="payment-body">
+    <header class="payment-header">
+        <a class="payment-logo" href="index.html">
+            <img src="assets/images/logo ian personal.png" alt="Ian Siqueira Personal Trainer">
+        </a>
+    </header>
+
+    <main class="payment-main">
+        <section class="payment-card confirmation-card">
+            <div class="payment-tag">
+                <i class="fas fa-check-circle"></i>
+                Pagamento confirmado
+            </div>
+            <h1>Obrigado por concluir o pagamento!</h1>
+            <p class="payment-subtitle">
+                Assim que você clicar no botão abaixo, registramos sua confirmação e liberamos o próximo passo
+                automaticamente.
+            </p>
+
+            <div class="confirmation-details">
+                <div class="confirmation-item">
+                    <span class="confirmation-label">Status</span>
+                    <span class="confirmation-value">Pagamento efetuado</span>
+                </div>
+                <div class="confirmation-item">
+                    <span class="confirmation-label">Próximo passo</span>
+                    <span class="confirmation-value">Aguardar contato para onboarding</span>
+                </div>
+            </div>
+
+            <button class="btn btn-primary payment-cta" id="payment-confirm-btn" type="button"
+                data-webhook="https://seu-n8n-webhook.exemplo/webhook/pagamento-confirmado">
+                <i class="fas fa-check"></i>
+                Já paguei
+            </button>
+            <p class="payment-note">
+                Este botão dispara um gatilho automático para o N8N registrar seu pagamento.
+                Troque a URL do webhook acima quando configurar o fluxo.
+            </p>
+            <p class="confirmation-status" id="confirmation-status" role="status" aria-live="polite"></p>
+            <a class="payment-help" href="https://wa.me/55019997088455" target="_blank" rel="noopener">
+                <i class="fab fa-whatsapp"></i> Precisa de ajuda? Fale comigo
+            </a>
+        </section>
+    </main>
+
+    <script>
+        const confirmButton = document.getElementById('payment-confirm-btn');
+        const statusMessage = document.getElementById('confirmation-status');
+
+        confirmButton.addEventListener('click', () => {
+            const webhookUrl = confirmButton.dataset.webhook;
+
+            if (!webhookUrl || webhookUrl.includes('seu-n8n-webhook')) {
+                statusMessage.textContent = 'Configure a URL do webhook do N8N para registrar este pagamento.';
+                statusMessage.classList.add('is-warning');
+                return;
+            }
+
+            confirmButton.disabled = true;
+            confirmButton.classList.add('is-loading');
+            statusMessage.textContent = 'Registrando sua confirmação...';
+            statusMessage.classList.remove('is-warning');
+
+            const payload = {
+                status: 'paid',
+                page: 'payment-confirmation',
+                timestamp: new Date().toISOString()
+            };
+
+            const body = JSON.stringify(payload);
+            const blob = new Blob([body], { type: 'application/json' });
+            const beaconSent = navigator.sendBeacon && navigator.sendBeacon(webhookUrl, blob);
+
+            const finalize = (success) => {
+                confirmButton.disabled = false;
+                confirmButton.classList.remove('is-loading');
+                statusMessage.textContent = success
+                    ? 'Confirmação registrada! Em breve você receberá o contato.'
+                    : 'Não foi possível enviar agora. Tente novamente em instantes.';
+                statusMessage.classList.toggle('is-success', success);
+                statusMessage.classList.toggle('is-error', !success);
+            };
+
+            if (beaconSent) {
+                finalize(true);
+                return;
+            }
+
+            fetch(webhookUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body
+            })
+                .then(response => finalize(response.ok))
+                .catch(() => finalize(false));
+        });
+    </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1507,6 +1507,7 @@ h6 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 8px;
     background: rgba(255, 107, 53, 0.15);
     color: var(--primary);
     font-weight: 600;
@@ -1583,6 +1584,62 @@ h6 {
 
 .payment-help:hover {
     color: var(--primary);
+}
+
+.confirmation-card {
+    max-width: 560px;
+}
+
+.confirmation-details {
+    display: grid;
+    gap: 16px;
+    margin: 24px 0;
+    text-align: left;
+    border: 1px solid var(--border-light);
+    border-radius: 16px;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.confirmation-item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.confirmation-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #a7a7a7;
+}
+
+.confirmation-value {
+    font-weight: 600;
+}
+
+.confirmation-status {
+    margin-top: 16px;
+    font-size: 0.95rem;
+    color: #ccc;
+    min-height: 22px;
+}
+
+.confirmation-status.is-success {
+    color: #6ee7b7;
+}
+
+.confirmation-status.is-error {
+    color: #fca5a5;
+}
+
+.confirmation-status.is-warning {
+    color: #facc15;
+}
+
+.payment-cta.is-loading {
+    opacity: 0.75;
+    cursor: wait;
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
### Motivation

- Fornecer uma página acessada por redirecionamento pós-pagamento que permita ao usuário confirmar o pagamento e disparar um gatilho para um fluxo no N8N.

### Description

- Adiciona `payment-confirmation.html` com interface de confirmação, texto de agradecimento e um botão `Já paguei` que possui o atributo `data-webhook` para apontar ao webhook do N8N.
- Implementa lógica JavaScript na página que tenta enviar o payload via `navigator.sendBeacon` e, em fallback, `fetch`, exibindo mensagens de status (`is-success`, `is-error`, `is-warning`).
- Atualiza `style.css` para suportar o novo layout (`.confirmation-card`, `.confirmation-details`, `.confirmation-status`) e adiciona estado visual de carregamento no botão (`.payment-cta.is-loading`) e espaçamento no `payment-tag`.
- A página contém instrução clara para substituir a URL do webhook (`data-webhook`) quando o fluxo do N8N for configurado.

### Testing

- Levantado um servidor estático local com `python -m http.server 8000` e a página foi servida com sucesso. (sucesso)
- Rodado um script Playwright que abriu `http://localhost:8000/payment-confirmation.html` e gerou um screenshot (`artifacts/payment-confirmation.png`), confirmando o carregamento e layout da página. (sucesso)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f26ec610832390bef96b07e77de7)